### PR TITLE
8323879: constructor Path(Path) which takes another Path object fail to draw on canvas html

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/PathJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/PathJava.cpp
@@ -118,7 +118,7 @@ PathJava::PathJava(RefPtr<RQRef>&& platformPath, std::unique_ptr<PathStream>&& e
 
 UniqueRef<PathImpl> PathJava::clone() const
 {
-    auto platformPathCopy = createEmptyPath();
+    RefPtr<RQRef> platformPathCopy(copyPath(platformPath()));
 
     auto elementsStream = m_elementsStream ? m_elementsStream->clone().moveToUniquePtr() : nullptr;
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/PathContructorTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/PathContructorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+public class PathContructorTest extends TestBase {
+
+    @Test public void testCanvasPathConstructor() {
+        final String htmlCanvasContent = "<!DOCTYPE html>\n" +
+                "<html>\n" +
+                "<body style='margin: 0px 0px;'>\n" +
+                "<canvas id=\"myCanvas\" width=\"200\" height=\"100\" style=\"border:1px solid grey;\"></canvas>\n" +
+                "<script>\n" +
+                "const canvas = document.getElementById(\"myCanvas\");\n" +
+                "const ctx = canvas.getContext(\"2d\");\n" +
+                "p1 = new Path2D();\n" +
+                "p1.rect(0,0,200,200);\n" +
+                "ctx.fillStyle = 'yellow';\n" +
+                "ctx.fill(p1);\n" +
+                "p2 = new Path2D(p1);\n" +
+                "ctx.fillStyle = 'green';\n" +
+                "ctx.fill(p2);\n" +
+                "</script>\n" +
+                "</body>\n" +
+                "</html>";
+
+        loadContent(htmlCanvasContent);
+
+        submit(() -> {
+            int greenColor = 128;
+            assertEquals("First rect center", greenColor, (int) getEngine().executeScript(
+                    "document.getElementById('myCanvas').getContext('2d').getImageData(21, 21, 1, 1).data[1]"));
+        });
+    }
+}


### PR DESCRIPTION
A clean backport to jfx22u. The fix is for the canvas path constructor drawing with an old path on canvas, without the fix, the page crashes. I have tested the fix it is working with the fix and failing without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323879](https://bugs.openjdk.org/browse/JDK-8323879) needs maintainer approval

### Issue
 * [JDK-8323879](https://bugs.openjdk.org/browse/JDK-8323879): constructor Path(Path) which takes another Path object fail to draw on canvas html (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/5.diff">https://git.openjdk.org/jfx22u/pull/5.diff</a>

</details>
