### PR TITLE
Backport 1fb56e333bc65860cc1abeebd1cbb01cd8b8e5f3

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCascade.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCascade.h
@@ -293,7 +293,19 @@ private:
 
     bool advancedTextRenderingMode() const
     {
+#if !PLATFORM(JAVA)
         return m_fontDescription.textRenderingMode() != TextRenderingMode::OptimizeSpeed;
+#else
+        //The current implementation of complex text rendering path on the Java platform is experiencing
+        //side effects. We need to align with WebKit 616.1 standards.
+        auto textRenderingMode = m_fontDescription.textRenderingMode();
+        if (textRenderingMode == TextRenderingMode::GeometricPrecision || textRenderingMode == TextRenderingMode::OptimizeLegibility)
+            return true;
+        if (textRenderingMode == TextRenderingMode::OptimizeSpeed)
+            return false;
+
+        return false;
+#endif
     }
 
     bool computeEnableKerning() const


### PR DESCRIPTION
A clean backport to jfx22u. The fix is for rtl text issue, where the caret position is at the wrong position. I have tested the fix it is working with the fix and failing without the fix.