### PR TITLE
8325154: resizeColumnToFitContent is slower than it needs to be

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -660,11 +660,11 @@ public class TableColumnHeader extends Region {
 
         int rows = maxRows == -1 ? items.size() : Math.min(items.size(), maxRows);
         double maxWidth = 0;
+        cell.updateTableColumn(tc);
+        cell.updateTableView(tv);
         for (int row = 0; row < rows; row++) {
             tableRow.updateIndex(row);
 
-            cell.updateTableColumn(tc);
-            cell.updateTableView(tv);
             cell.updateTableRow(tableRow);
             cell.updateIndex(row);
 
@@ -754,12 +754,12 @@ public class TableColumnHeader extends Region {
 
         int rows = maxRows == -1 ? items.size() : Math.min(items.size(), maxRows);
         double maxWidth = 0;
+        cell.updateTableColumn(tc);
+        cell.updateTreeTableView(ttv);
         for (int row = 0; row < rows; row++) {
             treeTableRow.updateIndex(row);
             treeTableRow.updateTreeItem(ttv.getTreeItem(row));
 
-            cell.updateTableColumn(tc);
-            cell.updateTreeTableView(ttv);
             cell.updateTableRow(treeTableRow);
             cell.updateIndex(row);
 


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [e2f42c5b](https://github.com/openjdk/jfx/commit/e2f42c5b71ef061c614540508fbac3fb610b1ae3) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Robert Lichtenberger on 14 Feb 2024 and was reviewed by Andy Goryachev and Marius Hanl.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8325154](https://bugs.openjdk.org/browse/JDK-8325154) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325154](https://bugs.openjdk.org/browse/JDK-8325154): resizeColumnToFitContent is slower than it needs to be (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/14.diff">https://git.openjdk.org/jfx22u/pull/14.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx22u/pull/14#issuecomment-1950296438)