### PR TITLE
8327177: macOS: wrong GlobalRef deleted in GlassMenu

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -649,6 +649,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacMenuDelegate__1setCallback
         GlassMenu *menu = (GlassMenu *)jlong_to_ptr(jMenuPtr);
         GET_MAIN_JENV;
         (*env)->DeleteGlobalRef(env, menu->jCallback);
+        menu->jCallback = NULL;
         if (jCallback != NULL)
         {
             menu->jCallback = (*env)->NewGlobalRef(env, jCallback);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327177](https://bugs.openjdk.org/browse/JDK-8327177) needs maintainer approval

### Issue
 * [JDK-8327177](https://bugs.openjdk.org/browse/JDK-8327177): macOS: wrong GlobalRef deleted in GlassMenu (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/16.diff">https://git.openjdk.org/jfx22u/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx22u/pull/16#issuecomment-1979210629)