### PR TITLE
8326989: Text selection issues on WebView after WebKit 617.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
@@ -480,8 +480,12 @@ void FrameSelection::setSelection(const VisibleSelection& selection, OptionSet<S
     if (frameView && frameView->layoutContext().isLayoutPending())
         return;
 
-    if (!(options & SetSelectionOption::IsUserTriggered))
+    if (!(options & SetSelectionOption::IsUserTriggered)) {
+#if PLATFORM(JAVA)
+        updateSelectionAppearanceNow();
+#endif
         return;
+    }
 
     updateAndRevealSelection(intent, options.contains(SetSelectionOption::SmoothScroll) ? ScrollBehavior::Smooth : ScrollBehavior::Instant,
         options.contains(SetSelectionOption::RevealSelectionBounds) ? RevealExtentOption::DoNotRevealExtent : RevealExtentOption::RevealExtent,


### PR DESCRIPTION
Clean Backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326989](https://bugs.openjdk.org/browse/JDK-8326989) needs maintainer approval

### Issue
 * [JDK-8326989](https://bugs.openjdk.org/browse/JDK-8326989): Text selection issues on WebView after WebKit 617.1 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/18.diff">https://git.openjdk.org/jfx22u/pull/18.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx22u/pull/18#issuecomment-1983437297)