### PR TITLE
8328749: Remove unused imports in javafx.web

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMWindowImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMWindowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
 
 package com.sun.webkit.dom;
 
-import com.sun.webkit.Disposer;
-import com.sun.webkit.DisposerRecord;
-import com.sun.webkit.dom.JSObject;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -37,6 +34,7 @@ import org.w3c.dom.events.EventListener;
 import org.w3c.dom.events.EventTarget;
 import org.w3c.dom.views.AbstractView;
 import org.w3c.dom.views.DocumentView;
+import com.sun.webkit.Disposer;
 
 public class DOMWindowImpl extends JSObject implements AbstractView, EventTarget {
     // We use a custom hash-table rather than java.util.HashMap,

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
 
 package com.sun.webkit.dom;
 
-import com.sun.webkit.Disposer;
-import com.sun.webkit.DisposerRecord;
-import com.sun.webkit.dom.JSObject;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -38,6 +35,7 @@ import org.w3c.dom.UserDataHandler;
 import org.w3c.dom.events.Event;
 import org.w3c.dom.events.EventListener;
 import org.w3c.dom.events.EventTarget;
+import com.sun.webkit.Disposer;
 
 public class NodeImpl extends JSObject implements Node, EventTarget {
     // We use a custom hash-table rather than java.util.HashMap,

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,13 @@
 
 package test.javafx.scene.web;
 
-import javafx.concurrent.Worker.State;
-
-import static javafx.concurrent.Worker.State.SUCCEEDED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import java.util.concurrent.CountDownLatch;
-
-import org.junit.Test;
 import java.io.File;
-import java.io.IOException;
-import javafx.scene.web.WebView;
+import javafx.concurrent.Worker.State;
 import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import org.junit.Test;
 
 public class WebWorkerTest extends TestBase {
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a85af134](https://urldefense.com/v3/__https://github.com/openjdk/jfx/commit/a85af134f9255f140ea8f9f8e63a19e74f2d1731__;!!ACWV5N9M2RV99hQ!OtQmI24diE6uzrrVGadETfh3W-uWRrc5i2-yKL1pWL3y_6JeJ0IpXtnRLh6RQL8axenA6uT-fVigocRTOrnQkzSIIdt2OA$) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Andy Goryachev on 1 Apr 2024 and was reviewed by Hima Bindu Meda and Kevin Rushforth.

Thanks!


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8328749](https://bugs.openjdk.org/browse/JDK-8328749) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328749](https://bugs.openjdk.org/browse/JDK-8328749): Remove unused imports in javafx.web (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/22.diff">https://git.openjdk.org/jfx22u/pull/22.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx22u/pull/22#issuecomment-2030638840)