### PR TITLE
8329794: Create release notes for JavaFX 22.0.1

### DIFF
--- a/doc-files/release-notes-22.0.1.md
+++ b/doc-files/release-notes-22.0.1.md
@@ -1,0 +1,30 @@
+# Release Notes for JavaFX 22.0.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 22.0.1 update release. As such, they complement the [JavaFX 22](https://github.com/openjdk/jfx22u/blob/master/doc-files/release-notes-22.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8325154](https://bugs.openjdk.org/browse/JDK-8325154)|resizeColumnToFitContent is slower than it needs to be|controls
+[JDK-8311492](https://bugs.openjdk.org/browse/JDK-8311492)|FontSmoothingType LCD produces wrong color when transparency is used|graphics
+[JDK-8324233](https://bugs.openjdk.org/browse/JDK-8324233)|Update JPEG Image Decoding Software to 9f|graphics
+[JDK-8318614](https://bugs.openjdk.org/browse/JDK-8318614)|Update WebKit to 617.1|web
+[JDK-8322703](https://bugs.openjdk.org/browse/JDK-8322703)|Intermittent crash in WebView in a JFXPanel from IME calls on macOS|web
+[JDK-8323879](https://bugs.openjdk.org/browse/JDK-8323879)|constructor Path(Path) which takes another Path object fail to draw on canvas html|web
+[JDK-8323880](https://bugs.openjdk.org/browse/JDK-8323880)|Caret rendered at wrong position in case of a click event on RTL text|web
+[JDK-8324337](https://bugs.openjdk.org/browse/JDK-8324337)|Cherry-pick WebKit 617.1 stabilization fixes|web
+[JDK-8325258](https://bugs.openjdk.org/browse/JDK-8325258)|Additional WebKit 617.1 fixes from WebKitGTK 2.42.5|web
+[JDK-8326989](https://bugs.openjdk.org/browse/JDK-8326989)|Text selection issues on WebView after WebKit 617.1|web
+[JDK-8327177](https://bugs.openjdk.org/browse/JDK-8327177)|macOS: wrong GlobalRef deleted in GlassMenu|window-toolkit
+
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+JDK-nnnnnnn (not public)|TITLE|SUBCOMPONENT


### PR DESCRIPTION
Release notes for JavaFX 21.0.2.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=45526

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=45525

As usual, I excluded test bugs, cleanup bugs, etc.

NOTE: Once the CPU release ships on 2023-04-16, I will add any security bugs and make this PR `rfr`.
