### PR TITLE
8322251: [Linux] JavaFX is not displaying CJK on Ubuntu 23.10 and later

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
@@ -410,9 +410,13 @@ Java_com_sun_javafx_font_FontConfigManager_getFontConfig
 
             fontformat = NULL;
             (*FcPatternGetString)(fontPattern, FC_FONTFORMAT, 0, &fontformat);
-            /* We only want TrueType fonts for Java FX */
-            if (fontformat != NULL
-                && (strcmp((char*)fontformat, "TrueType") != 0)) {
+            /* We only want OpenType fonts for Java FX :
+             * ie TrueType and CFF format fonts.
+             */
+            if ((fontformat != NULL) &&
+                ((strcmp((char*)fontformat, "TrueType") != 0) &&
+                 (strcmp((char*)fontformat, "CFF") != 0)))
+            {
                 continue;
             }
             result = (*FcPatternGetCharSet)(fontPattern,


### PR DESCRIPTION
Backport to jfx22u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322251](https://bugs.openjdk.org/browse/JDK-8322251) needs maintainer approval

### Issue
 * [JDK-8322251](https://bugs.openjdk.org/browse/JDK-8322251): [Linux] JavaFX is not displaying CJK on Ubuntu 23.10 and later (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/27.diff">https://git.openjdk.org/jfx22u/pull/27.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx22u/pull/27#issuecomment-2078044294)