### PR TITLE
8332328: [GHA] GitHub Actions build fails on Linux: unable to find gcc-13

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -63,7 +63,7 @@ jobs:
   linux_x64_build:
     name: Linux x64
     needs: validation
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     env:
       # FIXME: read this information from a property file


### PR DESCRIPTION
Clean backport of Linux GHA fix to jfx22u (so we can get clean GHA runs for future 22u backports)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332328](https://bugs.openjdk.org/browse/JDK-8332328) needs maintainer approval

### Issue
 * [JDK-8332328](https://bugs.openjdk.org/browse/JDK-8332328): [GHA] GitHub Actions build fails on Linux: unable to find gcc-13 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/29.diff">https://git.openjdk.org/jfx22u/pull/29.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx22u/pull/29#issuecomment-2116307245)