### PR TITLE
8336327: Create release notes for JavaFX 22.0.2

### DIFF
--- a/doc-files/release-notes-22.0.2.md
+++ b/doc-files/release-notes-22.0.2.md
@@ -20,6 +20,4 @@ Issue key|Summary|Subcomponent
 
 ## List of Security fixes
 
-Issue key|Summary|Subcomponent
----------|-------|------------
-JDK-nnnnnnn (not public)|TITLE|SUBCOMPONENT
+NONE

--- a/doc-files/release-notes-22.0.2.md
+++ b/doc-files/release-notes-22.0.2.md
@@ -1,0 +1,25 @@
+# Release Notes for JavaFX 22.0.2
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 22.0.2 update release. As such, they complement the [JavaFX 22](https://github.com/openjdk/jfx22u/blob/master/doc-files/release-notes-22.md) and [JavaFX 22.0.1](https://github.com/openjdk/jfx22u/blob/master/doc-files/release-notes-22.0.1.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8329705](https://bugs.openjdk.org/browse/JDK-8329705)|Add missing Application thread checks to platform specific a11y methods|accessibility
+[JDK-8330462](https://bugs.openjdk.org/browse/JDK-8330462)|StringIndexOutOfBoundException when typing anything into TextField|accessibility
+[JDK-8322251](https://bugs.openjdk.org/browse/JDK-8322251)|[Linux] JavaFX is not displaying CJK on Ubuntu 23.10 and later|graphics
+[JDK-8324326](https://bugs.openjdk.org/browse/JDK-8324326)|Update ICU4C to 74.2|web
+[JDK-8329011](https://bugs.openjdk.org/browse/JDK-8329011)|Update SQLite to 3.45.3|web
+[JDK-8331748](https://bugs.openjdk.org/browse/JDK-8331748)|Update libxml2 to 2.12.6|web
+[JDK-8332539](https://bugs.openjdk.org/browse/JDK-8332539)|Update libxml2 to 2.12.7|web
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+JDK-nnnnnnn (not public)|TITLE|SUBCOMPONENT


### PR DESCRIPTION
Release notes for JavaFX 22.0.2.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=45846

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=45845

As usual, I excluded test bugs, cleanup bugs, etc.

NOTE: Once the CPU release ships on 2024-07-16, I will add any security bugs and make this PR `rfr`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336327](https://bugs.openjdk.org/browse/JDK-8336327) needs maintainer approval

### Issue
 * [JDK-8336327](https://bugs.openjdk.org/browse/JDK-8336327): Create release notes for JavaFX 22.0.2 (**Task** - P2 - Approved)


### Reviewers
 * @abhinayagarwal (no known openjdk.org user name / role)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx22u.git pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jfx22u.git pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx22u/pull/33.diff">https://git.openjdk.org/jfx22u/pull/33.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx22u/pull/33#issuecomment-2230644903)